### PR TITLE
Sort the options in the template before building it

### DIFF
--- a/templates/dnsmasq/config_options.conf.erb
+++ b/templates/dnsmasq/config_options.conf.erb
@@ -1,5 +1,5 @@
 # Puppet managed options
 
-<%- @options.each do |key, val| -%>
+<%- @options.sort.each do |key, val| -%>
 <%= key %><%- if val != '' -%>=<%= val %><%- end %>
 <%- end -%>


### PR DESCRIPTION
The options array in the config_options.conf.erb template should be
sorted before the file is generated. This allow the file to be produced
in a deterministic way, puppet to run idempotently and the subscribed
services not to be refreshed.
